### PR TITLE
Daily New Accounts by Contract (new) table

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -7,23 +7,56 @@ CREATE ROLE readonly;
 GRANT USAGE ON SCHEMA public TO readonly;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO readonly;
 
-CREATE USER mainnet with password 'password';
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO mainnet;
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO mainnet;
-
-CREATE TABLE daily_statistics
+CREATE TABLE daily_transactions_count
 (
-    computed_for_timestamp     numeric(20, 0) NOT NULL,
-    transactions_count         numeric(20, 0) NOT NULL,
-    teragas_used               numeric(20, 0) NOT NULL,
-    deposit_amount             numeric(45, 0) NOT NULL,
-    new_accounts_count         numeric(20, 0) NOT NULL,
-    deleted_accounts_count     numeric(20, 0) NOT NULL,
-    active_accounts_count      numeric(20, 0) NOT NULL,
-    new_contracts_count        numeric(20, 0) NOT NULL,
-    new_unique_contracts_count numeric(20, 0) NOT NULL,
-    active_contracts_count     numeric(20, 0) NOT NULL
+    daily_timestamp    numeric(20, 0) PRIMARY KEY,
+    transactions_count numeric(20, 0) NOT NULL
 );
 
-ALTER TABLE ONLY daily_statistics
-    ADD CONSTRAINT daily_statistics_pkey PRIMARY KEY (computed_for_timestamp);
+CREATE TABLE daily_teragas_used
+(
+    daily_timestamp numeric(20, 0) PRIMARY KEY,
+    teragas_used    numeric(20, 0) NOT NULL
+);
+
+CREATE TABLE daily_deposit_amount
+(
+    daily_timestamp numeric(20, 0) PRIMARY KEY,
+    deposit_amount  numeric(45, 0) NOT NULL
+);
+
+CREATE TABLE daily_new_accounts_count
+(
+    daily_timestamp    numeric(20, 0) PRIMARY KEY,
+    new_accounts_count numeric(20, 0) NOT NULL
+);
+
+CREATE TABLE daily_deleted_accounts_count
+(
+    daily_timestamp        numeric(20, 0) PRIMARY KEY,
+    deleted_accounts_count numeric(20, 0) NOT NULL
+);
+
+CREATE TABLE daily_active_accounts_count
+(
+    daily_timestamp       numeric(20, 0) PRIMARY KEY,
+    active_accounts_count numeric(20, 0) NOT NULL
+);
+
+CREATE TABLE daily_new_contracts_count
+(
+    daily_timestamp     numeric(20, 0) PRIMARY KEY,
+    new_contracts_count numeric(20, 0) NOT NULL
+);
+
+CREATE TABLE daily_new_unique_contracts_count
+(
+    daily_timestamp            numeric(20, 0) PRIMARY KEY,
+    new_unique_contracts_count numeric(20, 0) NOT NULL
+);
+
+CREATE TABLE daily_active_contracts_count
+(
+    daily_timestamp        numeric(20, 0) PRIMARY KEY,
+    active_contracts_count numeric(20, 0) NOT NULL
+);


### PR DESCRIPTION
The request is based on the following mock up: https://gov.near.org/t/analytics-dashboard/3771, which would basically contain data for Accounts and Apps with date timeframe granularity.

We already have access to create Total/Active Accounts visualizations (e.g.) using the `daily_active_accounts_count` table:

```
select
	collected_for_day as date
	, date_trunc('week', collected_for_day)::date as week
	, active_accounts_count
from
	daily_active_accounts_count
```
	
Nonetheless, we're lacking of data for Apps metrics (Accounts and New Accounts). For that, we could use the `daily_receipts_per_contract_count` _just as an example_ of table structure for what we're looking for. Assuming that an App is a group of Contracts - we may definitely clarify on that - our new table would include the following fields:

- collected_for_day
- contract_id
- app_id (based on the manually curated list of apps)
- new_accounts_count
- active_accounts_count

So actually from this table we could generate not only all Apps metrics, but also the first KPI designed (Total/Active Accounts). For each one of them ([here](https://gov.near.org/t/analytics-dashboard/3771), again), the fields we would need are:

1. **Total Accounts** (`collected_for_day` and `active_accounts_count`)
2. **Top Apps by Number of New Accounts** (I believe we're talking about the accumulated number of active accounts 'as of today' here, so `app_id` and `active_accounts_count`)
3. **Total Accounts by App** (`collected_for_day`, `app_id` and `active_accounts_count`)
4. **New Accounts by App** (that's interesting. It seems that we're going to need to make (today() - interval 90 days) as the new start date and accumulate date from there, so `collected_for_day`, `app_id` and a new column based on `active_accounts_count` with a calculation)
5. **Table App Momentum** (`app_id` and `active_accounts_count`)

I'm really looking forward to knowing your thoughts about this structure! Do you think that would work? Feel free to reach out and schedule a call to discuss!